### PR TITLE
exportCreateUsers doesn't work right

### DIFF
--- a/administrator/components/com_kunenaimporter/models/export.php
+++ b/administrator/components/com_kunenaimporter/models/export.php
@@ -463,11 +463,12 @@ class KunenaimporterModelExport extends JModel {
 		$db = JFactory::getDBO();
 		$query = "SELECT * FROM #__kunenaimporter_users ORDER BY extid";
 		$db->setQuery ( $query, $start, $limit );
-		$extusers = $db->loadObjectList ( 'id' );
+		$extusers = $db->loadObjectList ( 'extid' );
 		$users = array();
 		foreach ($extusers as $user) {
 			$extuser = JTable::getInstance ( 'ExtUser', 'KunenaImporterTable' );
-			$extuser->load ( $user->extid );
+			$extuser->bind ( get_object_vars($user) );
+			$extuser->exists ( true );
 			$users[] = $extuser;
 		}
 		return $users;


### PR DESCRIPTION
Hello,
It seems that currently users export doesn't work at all.
Here's explanation:

// We're importing users from the import table. If I get it right, the column 'id' should be NULL at this moment.
$query = "SELECT \* FROM #__kunenaimporter_users ORDER BY extid";

// loadObjectList($key) - Joomla docs says the following: "If $key is not empty then the returned array is indexed by the value the database key.
$extusers = $db->loadObjectList ( 'id' );

// Hence all results are indexed by NULL, literally in code:
// foreach ($users as $user) {
//   $users[null] = $user;
// }

What I think it should look like:

$extusers = $db->loadObjectList ( 'extid' );

So the code will be:

foreach ($users as $user) {
   $users[$user->extid] = $user;
}
